### PR TITLE
[WIP] Remove '(Testing) ' prefix

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -1,5 +1,4 @@
 app-id: com.google.Chrome
-desktop-file-name-prefix: '(Testing) '
 runtime: org.freedesktop.Platform
 runtime-version: '19.08'
 sdk: org.freedesktop.Sdk


### PR DESCRIPTION
The fact that this is only available only for `flathub-beta` makes implicit that this is testing/beta software. 

In GNOME the app might be as well called `(Testing) Google`.

![image](https://user-images.githubusercontent.com/11528996/90416298-d2403080-e0a1-11ea-8d3d-77571084b421.png)
