### PR TITLE
Remove verbose flag

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/sh
 ar x chrome.deb data.tar.xz
 rm chrome.deb
-tar -xvf data.tar.xz --strip-components=4 ./opt/google/chrome
+tar -xf data.tar.xz --strip-components=4 ./opt/google/chrome
 rm data.tar.xz nacl*
 cp /app/bin/stub_sandbox chrome-sandbox


### PR DESCRIPTION
This MR removes the verbose flag in order to stop the extraction from spamming in the terminal.