### PR TITLE
Allow to access Pictures folder in Home directory

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -32,6 +32,7 @@ finish-args:
   - '--filesystem=xdg-download'
   - '--filesystem=xdg-music'
   - '--filesystem=xdg-videos'
+  - '--filesystem=xdg-pictures'
 modules:
   - libsecret.json
 


### PR DESCRIPTION
Browsers interact with a lot of websites for uploading pictures. This change doesn't restore the whole home access as it was before, but gives access to the Pictures directory, adding it to the Documents, Downloads, Music and Videos directories that already were allowed.

This would close https://github.com/flathub/com.google.Chrome/issues/46