### PR TITLE
Disable the WASM trap handler

### DIFF
--- a/chrome.sh
+++ b/chrome.sh
@@ -32,6 +32,9 @@ if [[ ! -f "$mimic_stamp" ]] && ! zypak-helper spawn-strategy-test; then
   touch "$mimic_stamp"
 fi
 
+# Workaround for https://github.com/flathub/org.chromium.Chromium/issues/104
+set -- --disable-features=WebAssemblyTrapHandler "$@"
+
 if [[ -f "$XDG_CONFIG_HOME/chrome-flags.conf" ]]; then
   IFS=$'\n'
   flags=($(grep -v '^#' "$XDG_CONFIG_HOME/chrome-flags.conf"))


### PR DESCRIPTION
Closes #104.

@PoignardAzur any chance you could send the emcc .html file you used for testing? I was trying to test it myself but cannot get emcc to work for the life of me (somehow I have managed to make the prebuilt Node segfault) :sweat_smile: so having it would be great for testing as I try to work around this in Chromium too.