### PR TITLE
Move metainfo copyright to second line

### DIFF
--- a/com.google.Chrome.metainfo.xml
+++ b/com.google.Chrome.metainfo.xml
@@ -1,5 +1,5 @@
-<!-- Copyright 2017 the Chromium authors, with modifications -->
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 the Chromium authors, with modifications -->
 <component type="desktop">
   <id>com.google.Chrome</id>
   <launchable type="desktop-id">com.google.Chrome.desktop</launchable>


### PR DESCRIPTION
Currently XML parsing fails with
```
com.google.Chrome.metainfo.xml:2:0: XML or text declaration not at start of entity
```
This prevents flatpak-external-data-checker from adding releases to `.metainfo.xml`. Moving the copyright comment below XML declaration fixes the issue and should re-enable automatic addition of releases.