### PR TITLE
Set is-main-source: true for Chrome deb

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -165,6 +165,7 @@ modules:
           dist: stable
           component: main
           package-name: google-chrome-stable
+          is-main-source: true
       - type: script
         dest-filename: stub_sandbox.sh
         commands:


### PR DESCRIPTION
This avoids the following warning:
    
    WARNING src.checker: Guessed upstream source: extra-data chrome.deb

TODO:

- [x] Run f-e-d-c against this branch