### PR TITLE
Add support for kerberos authentication

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -49,6 +49,14 @@ modules:
     subdir: src
     post-install:
       - install -Dm644 ../krb5.conf /app/etc/krb5.conf
+    cleanup:
+      - /bin
+      - /sbin
+      - /include
+      - /share/examples
+      - /share/man
+      - '*.pc'
+      - '*.mo'
     sources:
       - type: archive
         url: https://kerberos.org/dist/krb5/1.19/krb5-1.19.2.tar.gz

--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -25,6 +25,7 @@ finish-args:
   - --talk-name=org.gnome.SessionManager
   - --system-talk-name=org.freedesktop.Avahi
   - --own-name=org.mpris.MediaPlayer2.chromium.*
+  - --filesystem=/run/.heim_org.h5l.kcm-socket
   - --filesystem=host-etc
   - --filesystem=xdg-run/pipewire-0
   - --filesystem=xdg-documents
@@ -43,6 +44,22 @@ finish-args:
   - --filesystem=~/.config/kioslaverc
 modules:
   - libsecret.json
+
+  - name: kerberos
+    subdir: src
+    post-install:
+      - install -Dm644 ../krb5.conf /app/etc/krb5.conf
+    sources:
+      - type: archive
+        url: https://kerberos.org/dist/krb5/1.19/krb5-1.19.2.tar.gz
+        sha256: 10453fee4e3a8f8ce6129059e5c050b8a65dab1c257df68b99b3112eaa0cdf6a
+        x-checker-data:
+          type: html
+          url: https://kerberos.org/dist/
+          version-pattern: Kerberos V5 Release ([\d\.-]*) - current release
+          url-template: https://kerberos.org/dist/krb5/$version0.$version1/krb5-$version.tar.gz
+      - type: file
+        path: krb5.conf
 
   - name: libcups
     make-args: [libs]

--- a/krb5.conf
+++ b/krb5.conf
@@ -1,0 +1,10 @@
+[libdefaults]
+    dns_lookup_realm = false
+    ticket_lifetime = 24h
+    renew_lifetime = 7d
+    forwardable = true
+    rdns = false
+    pkinit_anchors = FILE:/etc/ssl/certs/ca-certificates.crt
+    spake_preauth_groups = edwards25519
+    default_ccache_name = KCM:
+


### PR DESCRIPTION
Freedesktop [removed support for kerberos auth](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1256
) due to lack of use. Add it to the Chrome flatpak since it is useful for web browsers to use kerberos authentication

Based on the [change in Firefox BaseApp](https://github.com/flathub/org.mozilla.firefox.BaseApp/commit/f8ef0b766cc23be262f5349947c0f2d3c4193b56)