### PR TITLE
Adding StartupWMClass to .desktop file

### DIFF
--- a/com.google.Chrome.desktop
+++ b/com.google.Chrome.desktop
@@ -107,6 +107,7 @@ Comment[zh_HK]=連線到網際網路
 Comment[zh_TW]=連線到網際網路
 Exec=/app/bin/chrome %U
 StartupNotify=true
+StartupWMClass=Google-chrome
 Terminal=false
 Icon=com.google.Chrome
 Type=Application


### PR DESCRIPTION
Without `StartupWMClass` in `.desktop` file, a desktop environment like Budgie is not able to pin the application in the task list applet. Therefore, adding one.