### PR TITLE
fix: fido2 support needs access to pcsc socket

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -16,6 +16,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=cups
+  - --socket=pcsc # FIDO2
   - --socket=pulseaudio
   - --socket=x11
   - --socket=wayland


### PR DESCRIPTION
In order for FIDO2 / WebAuthN to work chrome needs access to the pcsc socket. See also #148 