### PR TITLE
Bump org.freedesktop.Platform to 22.08

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -1,9 +1,9 @@
 app-id: com.google.Chrome
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 base: org.chromium.Chromium.BaseApp
-base-version: '21.08'
+base-version: '22.08'
 command: chrome
 separate-locales: false
 build-options:


### PR DESCRIPTION
Brings in updated libs, specially mesa for gpu drivers. Played a bit with it, it seems to work fine (tm)