### PR TITLE
Enable Darkmode

### DIFF
--- a/chrome.sh
+++ b/chrome.sh
@@ -13,4 +13,9 @@ for policy_type in managed recommended enrollment; do
   fi
 done
 
-exec cobalt "$@"
+if [[ $(gsettings get org.gnome.desktop.interface color-scheme) = "'prefer-dark'" ]] 
+then
+  exec cobalt "$@" --force-dark-mode --enable-features=WebUIDarkMode
+else
+  exec cobalt "$@"
+fi


### PR DESCRIPTION
Forces Chrome to start in dark-mode if system color scheme is set to 'prefer-dark'. 