### PR TITLE
Replace --socket=x11 with --socket=fallback-x11

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -18,7 +18,7 @@ finish-args:
   - --socket=cups
   - --socket=pcsc # FIDO2
   - --socket=pulseaudio
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --require-version=1.8.2
   - --system-talk-name=org.freedesktop.UPower


### PR DESCRIPTION
This is an  attempt to get rid of the security warning in the flathub software thingy:
![Screenshot from 2023-01-06 09-13-21](https://user-images.githubusercontent.com/2416031/211029557-063ec1ca-ffbb-4711-9181-8c9c5e4da163.png)
I got the idea here: https://www.reddit.com/r/Fedora/comments/tpsret/how_can_i_force_flatpak_apps_to_run_on_wayland/
CAUTION: I'm a total flatpak noob.  I didn't try this out - I don't even know how yet.  Only searched the issues for this project for fallback-x11.  Just thought this was the most specific way to open an issue.