### PR TITLE
Enabled PWAs

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -46,6 +46,9 @@ finish-args:
   - --env=GSETTINGS_BACKEND=dconf
   # For KDE proxy resolution (KDE5 only)
   - --filesystem=~/.config/kioslaverc
+  # To allow installing Progressive Web Apps (PWAs)
+  - --filesystem=~/.local/share/applications
+  - --filesystem=~/.local/share/icons
 modules:
   - name: dconf
     buildsystem: meson


### PR DESCRIPTION
Added necessary filesystem access for installing Progressive Web Apps.  I got a warning when accessing various google services (like Google Docs) about how I needed to allow this access in order to install the PWA.  I did.  It worked.  Thought I'd contribute that upstream.  Thanks for this flatpak - love it!