### PR TITLE
Change socket=x11 to socket=fallback-x11

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -18,8 +18,8 @@ finish-args:
   - --socket=cups
   - --socket=pcsc # FIDO2
   - --socket=pulseaudio
-  - --socket=x11
   - --socket=wayland
+  - --socket=fallback-x11
   - --require-version=1.8.2
   - --system-talk-name=org.freedesktop.UPower
   - --talk-name=org.freedesktop.FileManager1


### PR DESCRIPTION
Allows systems with wayland available to enable only the wayland socket, and possibly avoid showing a "This app uses a legacy window system" warning.