### PR TITLE
Use newer freedesktop platform 23.08

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -1,9 +1,9 @@
 app-id: com.google.Chrome
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.chromium.Chromium.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 command: chrome
 separate-locales: false
 build-options:


### PR DESCRIPTION
A new version of the runtime was recently released, see [here](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases/freedesktop-sdk-23.08.0).

Needs https://github.com/flathub/org.chromium.Chromium.BaseApp/pull/30 first.