### PR TITLE
Use bsdtar to extract archive

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/sh
-ar x chrome.deb data.tar.xz
+set -e
+
+bsdtar -Oxf chrome.deb data.tar.xz |
+  bsdtar -xf - \
+    --strip-components=4 \
+    --exclude='./opt/google/chrome/nacl*' \
+    ./opt/google/chrome
 rm chrome.deb
-tar -xf data.tar.xz --strip-components=4 ./opt/google/chrome
-rm data.tar.xz nacl*
-cp /app/bin/stub_sandbox chrome-sandbox
+
+install -Dm 755 /app/bin/stub_sandbox chrome-sandbox

--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -97,10 +97,6 @@ modules:
         for icon in 16 24 32 48 64 128 256; do
           install -Dm 644 com.google.Chrome-$icon.png /app/share/icons/hicolor/${icon}x${icon}/apps/com.google.Chrome.png
         done
-
-      # For extra-data to be able to extract the .deb
-      - install -Dm 755 /{usr,app}/bin/ar
-      - cp /usr/lib/$(gcc --print-multiarch)/libbfd-*.so /app/lib
     sources:
       - type: extra-data
         # From https://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages


### PR DESCRIPTION
Follows changes made in edge and others, and avoids the nasty hack of shipping host binaries in flatpaks.

Closes #240 