### PR TITLE
MetaInfo: Don't start with an article

### DIFF
--- a/com.google.Chrome.metainfo.xml
+++ b/com.google.Chrome.metainfo.xml
@@ -5,7 +5,7 @@
   <launchable type="desktop-id">com.google.Chrome.desktop</launchable>
   <name>Google Chrome</name>
   <developer_name>Google</developer_name>
-  <summary>The web browser from Google</summary>
+  <summary>Fast and easy to use web browser</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LicenseRef-proprietary</project_license>
   <url type="homepage">https://chrome.google.com/</url>


### PR DESCRIPTION
One of the [Flathub MetaInfo Quality Guidelines][1] Chrome is currently failing is its summary starts with an article. These guidelines should be followed for improved display across Flathub.

This PR reworks the summary, adapting copy from the Chrome app listing for Android while:

- Not repeating the developer name
- Keeping it under 35 characters

[1]: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines