### PR TITLE
MetaInfo: Add brand colors

### DIFF
--- a/com.google.Chrome.metainfo.xml
+++ b/com.google.Chrome.metainfo.xml
@@ -161,5 +161,9 @@
   </releases>
   <content_rating type="oars-1.1">
   </content_rating>
+  <branding>
+    <color type="primary" scheme_preference="light">#ddeeff</color>
+    <color type="primary" scheme_preference="dark">#174ea6</color>
+  </branding>
   <update_contact>rymg19_at_gmail.com</update_contact>
 </component>


### PR DESCRIPTION
To comply with the [Flathub MetaInfo Quality Guidelines][1], Chrome must include brand colors in its MetaInfo. These colors were chosen from google.com/chrome. You can preview them (or other colors) using the [Flathub brand color preview page][2].

![Screenshot 2024-04-22 at 15-17-01 Brand color preview Flathub Documentation](https://github.com/flathub/com.google.Chrome/assets/611168/d76df686-227e-4442-8ba0-abb3bfa9de10)

[1]: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines/
[2]: https://docs.flathub.org/banner-preview