### PR TITLE
Enable PWAs

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -48,6 +48,9 @@ finish-args:
   - --env=GSETTINGS_BACKEND=dconf
   # For KDE proxy resolution (KDE5 only)
   - --filesystem=~/.config/kioslaverc
+  # To allow installing Progressive Web Apps (PWAs)
+  - --filesystem=~/.local/share/applications:create
+  - --filesystem=~/.local/share/icons:create
 modules:
   - name: dconf
     buildsystem: meson


### PR DESCRIPTION
This pull request add the missing permissions for PWAs support out-of-the-box by adding ":create" missing from https://github.com/flathub/com.google.Chrome/pull/188
