### PR TITLE
Add talk permissions to non-freedesktop dbus screensaver apis

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -28,7 +28,11 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.gnome.SessionManager
+  - --talk-name=org.gnome.ScreenSaver
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.cinnamon.ScreenSaver
+  - --talk-name=org.mate.ScreenSaver
+  - --talk-name=org.xfce.ScreenSaver
   - --system-talk-name=org.freedesktop.Avahi
   - --own-name=org.mpris.MediaPlayer2.chromium.*
   - --filesystem=/run/.heim_org.h5l.kcm-socket


### PR DESCRIPTION
Had a user reporting locking on system lock not working in the Bitwarden browser extension on the Flatpak version of Brave. Chromium talks to more than just the freedesktop screensaver dbus interface (cf. https://github.com/chromium/chromium/blob/140ebdb86130d4a1bc3c5b08448897ea5c5bda56/ui/base/idle/idle_linux.cc#L44-L55) . Since the google-chrome flatpak manifest has the same permissions in this case, it causes the same issue as for Brave. This PR adds permission for the missing screensaver dbus apis. 