### PR TITLE
Cripto Nssdb plugin

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -48,6 +48,7 @@ finish-args:
   - --env=GSETTINGS_BACKEND=dconf
   # For KDE proxy resolution (KDE5 only)
   - --filesystem=~/.config/kioslaverc
+  - --persist=.pki
 modules:
   - name: dconf
     buildsystem: meson
@@ -127,13 +128,13 @@ modules:
       - type: file
         path: com.google.Chrome.svg
 add-extensions:
-  com.google.Chrome.nssdb:
+  com.google.Chrome.cripto:
     version: '1.0'
-    directory: nssdb
+    directory: cripto
     add-ld-path: lib
-    merge-dirs: nssdb;help
+    merge-dirs: lib;modules;bin
     subdirectories: true
     no-autodownload: true
     autodelete: true
 cleanup-commands:
-  - mkdir -p ${FLATPAK_DEST}/nssdb
+  - mkdir -p ${FLATPAK_DEST}/cripto

--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -126,3 +126,14 @@ modules:
         path: com.google.Chrome.metainfo.xml
       - type: file
         path: com.google.Chrome.svg
+add-extensions:
+  com.google.Chrome.nssdb:
+    version: '1.0'
+    directory: nssdb
+    add-ld-path: lib
+    merge-dirs: nssdb;help
+    subdirectories: true
+    no-autodownload: true
+    autodelete: true
+cleanup-commands:
+  - mkdir -p ${FLATPAK_DEST}/nssdb


### PR DESCRIPTION
Hi, I am writing a flatpak extension to enable the use of PKCS11 devices with the flatpak version of Chrome.
The goal is the extension to work with any type of PCSC enabled device, but there is some changes that are need on the Chrome Flatpak:
1) the persistense of ~/.pki/nssdb, not allowing the use of host folder
2) creation of a extension point for the plugins.
