### PR TITLE
Give access to host's /tmp

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -48,6 +48,8 @@ finish-args:
   - --env=GSETTINGS_BACKEND=dconf
   # For KDE proxy resolution (KDE5 only)
   - --filesystem=~/.config/kioslaverc
+  # To access to notification icon
+  - --filesystem=/tmp
 modules:
   - name: dconf
     buildsystem: meson


### PR DESCRIPTION
Access to host's tmp is needed to display correctly notification icon. See https://github.com/flathub/com.google.Chrome/issues/350