### PR TITLE
Bump freedesktop platform version to 25.08

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -1,9 +1,9 @@
 app-id: com.google.Chrome
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 base: org.chromium.Chromium.BaseApp
-base-version: '24.08'
+base-version: '25.08'
 command: chrome
 separate-locales: false
 build-options:


### PR DESCRIPTION
changed the runtime-version and base-version to org.freedesktop.Platform version 25.08