### PR TITLE
Switch to --socket=fallback-x11

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -18,7 +18,7 @@ finish-args:
   - --socket=cups
   - --socket=pcsc # FIDO2
   - --socket=pulseaudio
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --require-version=1.8.2
   - --system-talk-name=org.bluez


### PR DESCRIPTION
Chrome has switched to Wayland by default in one of the recent versions, so I think it makes sense to switch to
`--socket=fallback-x11`.