### PR TITLE
feat(a11y): add org.a11y.Bus permission

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -29,6 +29,7 @@ finish-args:
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.gnome.SessionManager
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.a11y.Bus
   - --system-talk-name=org.freedesktop.Avahi
   - --own-name=org.mpris.MediaPlayer2.chromium.*
   - --filesystem=/run/.heim_org.h5l.kcm-socket


### PR DESCRIPTION
allow screenreaders like Orca (GNOME) to correctly interact with webpages/forms

without it, Orca says "could not find current location" when e.g. tabbing into a form field.

with it, Orca says the correct field label e.g. "Email"