### PR TITLE
Add finish args required for QT theme

### DIFF
--- a/com.google.Chrome.yaml
+++ b/com.google.Chrome.yaml
@@ -48,6 +48,10 @@ finish-args:
   - --env=GSETTINGS_BACKEND=dconf
   # For KDE proxy resolution (KDE5 only)
   - --filesystem=~/.config/kioslaverc
+  # Qt Theme
+  - --filesystem=xdg-config/kdeglobals:ro
+  - --talk-name=org.kde.KGlobalSettings
+  - --talk-name=org.kde.kconfig.notify
 modules:
   - name: dconf
     buildsystem: meson


### PR DESCRIPTION
Depends on https://github.com/flathub/org.chromium.Chromium.BaseApp/pull/49. See that MR for a more detailed description.